### PR TITLE
Removed dependency of OS_AUTH_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,10 @@ export CLUSTER_ID=<cluster_id>
 export OS_USERNAME=<username>
 export OS_PASSWORD=<password>
 export OS_TENANT_NAME=<tenant>
-export OS_AUTH_URL=http://<ip_of_nailgun_host>:5000/v2.0
 
 ostf-config-extractor -o ostf.conf
 # or ostf-config-extractor --output ostf.conf
 ```
 
 By default, on MOS cloud there're username=admin, password=admin, tenant=admin,
-nailgun_port=8000, cluster_id=1. The parameter OS_AUTH_URL should point to
-Nailgun host, as the Extractor works definitely with Nailgun host only.
+nailgun_port=8000, cluster_id=1.

--- a/ostf_config_extractor/cmd.py
+++ b/ostf_config_extractor/cmd.py
@@ -418,8 +418,7 @@ def get_keystone_client():
     os_username = os.environ.get('OS_USERNAME', None)
     os_password = os.environ.get('OS_PASSWORD', None)
     nailgun_host = os.environ.get('NAILGUN_HOST', None)
-    os_auth_url = os.environ.get('OS_AUTH_URL',
-                          'http://{}:5000/v2.0/'.format(nailgun_host))
+    os_auth_url = 'http://{}:5000/v2.0/'.format(nailgun_host))
     os_region_name = os.environ.get('OS_REGION', None)
 
     __keystone_client = keystoneclient.Client(


### PR DESCRIPTION
Reasons:
    - In common, OS_AUTH_URL variable should point to Horizon auth point.
      Meanwhile, Extractor needs just a connection to Nailgun host, so there's
      no particular reason of keeping this dependency.
Changes:
    - OS_AUTH_URL will not be checked for auth_url. Instead, the direct usage
      of NAILGUN_HOST will be used.